### PR TITLE
 Resolve the issue of esbuild double initialization.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,11 @@ function App() {
   const [code, setCode] = useState(''); // To store tranpited code
 
   const startService = async () => {
-    await esbuild.initialize({wasmURL: '/esbuild.wasm'});
+    try {
+      await esbuild.initialize({wasmURL: '/esbuild.wasm'})
+    }
+    catch {
+    }
   }
 
   useEffect(()=> {


### PR DESCRIPTION
Mitigate double initialization in esbuild and handle useEffect redundancy in React strict mode by introducing a try-catch block.